### PR TITLE
MAINT: raise ValueError if data given to dwt or idwt is not 1D rather…

### DIFF
--- a/pywt/multidim.py
+++ b/pywt/multidim.py
@@ -53,7 +53,7 @@ def dwt2(data, wavelet, mode='sym'):
 
     """
     data = np.asarray(data)
-    if len(data.shape) != 2:
+    if data.ndim != 2:
         raise ValueError("Expected 2-D data array")
 
     if not isinstance(wavelet, Wavelet):
@@ -137,7 +137,7 @@ def idwt2(coeffs, wavelet, mode='sym'):
     for arr in (LL, LH, HL, HH):
         if arr is not None:
             all_none = False
-            if len(arr.shape) != 2:
+            if arr.ndim != 2:
                 raise TypeError("All input coefficients arrays must be 2D.")
 
     if all_none:
@@ -225,7 +225,7 @@ def dwtn(data, wavelet, mode='sym'):
 
     """
     data = np.asarray(data)
-    dim = len(data.shape)
+    dim = data.ndim
     if dim < 1:
         raise ValueError("Input data must be at least 1D")
     coeffs = [('', data)]
@@ -377,7 +377,7 @@ def swt2(data, wavelet, level, start_level=0):
 
     """
     data = np.asarray(data)
-    if len(data.shape) != 2:
+    if data.ndim != 2:
         raise ValueError("Expected 2D data array")
 
     if not isinstance(wavelet, Wavelet):

--- a/pywt/multilevel.py
+++ b/pywt/multilevel.py
@@ -152,7 +152,7 @@ def wavedec2(data, wavelet, mode='sym', level=None):
 
     data = np.asarray(data, np.float64)
 
-    if len(data.shape) != 2:
+    if data.ndim != 2:
         raise ValueError("Expected 2D input data.")
 
     if not isinstance(wavelet, Wavelet):

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -277,8 +277,8 @@ cdef public class Wavelet [type WaveletType, object WaveletObject]:
             except TypeError:
                 raise ValueError("Filter bank with numeric values required.")
 
-            if not (1 == len(dec_lo.shape) == len(dec_hi.shape) ==
-                         len(rec_lo.shape) == len(rec_hi.shape)):
+            if not (1 == dec_lo.ndim == dec_hi.ndim ==
+                         rec_lo.ndim == rec_hi.ndim):
                 raise ValueError("All filters in filter bank must be 1D.")
 
             filter_length = len(dec_lo)

--- a/pywt/src/_pywt.pyx
+++ b/pywt/src/_pywt.pyx
@@ -643,6 +643,8 @@ def dwt(object data, object wavelet, object mode='sym'):
     # accept array_like input; make a copy to ensure a contiguous array
     dt = _check_dtype(data)
     data = np.array(data, dtype=dt)
+    if data.ndim != 1:
+        raise ValueError("dwt requires a 1D data array.")
     return _dwt(data, wavelet, mode)
 
 
@@ -795,9 +797,13 @@ def idwt(cA, cD, object wavelet, object mode='sym', int correct_size=0):
     if cA is not None:
         dt = _check_dtype(cA)
         cA = np.array(cA, dtype=dt)
+        if cA.ndim != 1:
+            raise ValueError("idwt requires 1D coefficient arrays.")
     if cD is not None:
         dt = _check_dtype(cD)
         cD = np.array(cD, dtype=dt)
+        if cD.ndim != 1:
+            raise ValueError("idwt requires 1D coefficient arrays.")
 
     if cA is not None and cD is not None:
         if cA.dtype != cD.dtype:

--- a/pywt/tests/test_dwt_idwt.py
+++ b/pywt/tests/test_dwt_idwt.py
@@ -21,6 +21,14 @@ def test_dwt_idwt_basic():
     assert_allclose(x_roundtrip, x, rtol=1e-10)
 
 
+def test_dwt_input_error():
+    data = np.ones((16, 1))
+    assert_raises(ValueError, pywt.dwt, data, 'haar')
+
+    cA, cD = pywt.dwt(data[:, 0], 'haar')
+    assert_raises(ValueError, pywt.idwt, cA[:, np.newaxis], cD, 'haar')
+
+
 def test_dwt_wavelet_kwd():
     x = np.array([3, 7, 1, 1, -2, 5, 4, 6])
     w = pywt.Wavelet('sym3')

--- a/pywt/wavelet_packets.py
+++ b/pywt/wavelet_packets.py
@@ -543,7 +543,7 @@ class WaveletPacket(Node):
 
         if data is not None:
             data = np.asarray(data, dtype=np.float64)
-            assert len(data.shape) == 1
+            assert data.ndim == 1
             self.data_size = data.shape[0]
             if maxlevel is None:
                 maxlevel = dwt_max_level(self.data_size, self.wavelet)
@@ -645,7 +645,7 @@ class WaveletPacket2D(Node2D):
 
         if data is not None:
             data = np.asarray(data, dtype=np.float64)
-            assert len(data.shape) == 2
+            assert data.ndim == 2
             self.data_size = data.shape
             if maxlevel is None:
                 maxlevel = dwt_max_level(min(self.data_size), self.wavelet)


### PR DESCRIPTION
This adds a check on the dimension of the data passed to ``dwt`` or ``idwt``.  

I accidentally passed a 2D array of size (32, 1) to ``dwt`` and received the following traceback that I think would be obscure from a user perspective:

```python
Traceback (most recent call last):

  File "<ipython-input-113-018620631316>", line 1, in <module>
    coeffs = pywt.dwt(x, 'db1')

  File "_pywt.pyx", line 648, in _pywt.dwt (pywt/src/_pywt.c:9625)

  File "_pywt.pyx", line 651, in _pywt.__pyx_fused_cpdef (pywt/src/_pywt.c:10260)

TypeError: No matching signature found
```

